### PR TITLE
Remove duplicate pip installation instructions - fixes #15

### DIFF
--- a/_pages/adapt.md
+++ b/_pages/adapt.md
@@ -122,9 +122,6 @@ Install Adapt via `pip` into your project's `virtualenv`:
 $ sudo apt-get install virtualenv
 $ virtualenv myvirtualenv
 $ . myvirtualenv/bin/activate
-$ pip install -e git+https://github.com/mycroftai/adapt#egg=adapt-parser$ sudo apt-get install virtualenv
-$ virtualenv myvirtualenv
-$ . myvirtualenv/bin/activate
 $ pip install -e git+https://github.com/mycroftai/adapt#egg=adapt-parser
 ```
 


### PR DESCRIPTION
This removes the duplicate mention of commands to install Adapt via pip inside a virtualenv.