### PR TITLE
Update bluetooth instructions

### DIFF
--- a/_pages/picroft-audio.md
+++ b/_pages/picroft-audio.md
@@ -58,7 +58,7 @@ You can now run `./auto_run.sh` to start the program back up and test and ensure
 First, we need to enable Bluetooth. 
 
 1. Edit the `/etc/mycroft/mycroft.conf` file
-2. Add `"port": "/dev/ttyAMA1"` to the enclosure settings
+2. Add `"port": "/dev/ttyAMA0"` to the enclosure settings
 
 Next, we set up the Bluetooth connection. 
 


### PR DESCRIPTION
I needed to fix the https://github.com/MycroftAI/docs-rewrite/edit/master/_pages/picroft-audio.md#L61 from `/dev/ttyAMA1` to `/dev/ttyAMA0` this should now work. This was documented in 2017 against 0.8 by myself and @btotharye. This should help picroft users.