### PR TITLE
ISSUE #52 Fixed issue with bluetooth instructions

### DIFF
--- a/_pages/picroft-audio.md
+++ b/_pages/picroft-audio.md
@@ -58,7 +58,7 @@ You can now run `./auto_run.sh` to start the program back up and test and ensure
 First, we need to enable Bluetooth. 
 
 1. Edit the `/etc/mycroft/mycroft.conf` file
-2. Add `"port": "/dev/ttyAMA0"` to the enclosure settings
+2. Add `"port": "/dev/ttyAMA1"` to the enclosure settings
 
 Next, we set up the Bluetooth connection. 
 


### PR DESCRIPTION
Changed the enclosure port from /dev/ttyAMA0 to /dev/ttyAMA1. AMA0 is required for bluetooth, AMA1 can be used as the general purpose serial port.