### PR TITLE
Update conversational-context.md

### DIFF
--- a/_pages/conversational-context.md
+++ b/_pages/conversational-context.md
@@ -117,6 +117,8 @@ Mycroft: Here you go, here's your Tea with Honey
 ```
 
 ```python
+from mycroft.skills.context import adds_context, removes_context
+
 class TeaSkill(MycroftSkill):
     @intent_handler(IntentBuilder('TeaIntent').require("TeaKeyword"))
     @adds_context('MilkContext')
@@ -143,18 +145,18 @@ class TeaSkill(MycroftSkill):
     @removes_context('HoneyContext')
     def handle_no_honey_intent(self, message):
         if self.milk:
-            self.speak('Here's your Tea, straight up')
+            self.speak('Heres your Tea, straight up')
         else:
-            self.speak('Here's your Tea with a dash of Milk')
+            self.speak('Heres your Tea with a dash of Milk')
 
     @intent_handler(IntentBuilder('YesHoneyIntent').require("YesKeyword").
                                 require('HoneyContext').build())
     @removes_context('HoneyContext')
     def handle_yes_honey_intent(self, message):
         if self.milk:
-            self.speak('Here's your Tea with Milk and Honey')
+            self.speak('Heres your Tea with Honey')
         else:
-            self.speak('Here's your Tea with Honey')
+            self.speak('Heres your Tea with Milk and Honey')
 ```
 
 When starting up only the `TeaIntent` will be available. When that has been triggered and _MilkContext_ is added the `MilkYesIntent` and `MilkNoIntent` are available since the _MilkContext_ is set. when a _yes_ or _no_ is received the _MilkContext_ is removed and can't be accessed. In it's place the _HoneyContext_ is added making the `YesHoneyIntent` and `NoHoneyIntent` available.


### PR DESCRIPTION
All the recommended changes are for the "Using context to enable Intents" part of the "conversational-context.md" guide. 

**Recommendation 1: The speech for def handle_yes_honey_intent**
Since self.milk = False, milk must return False in the def handle_yes_honey_intent when one refuses Milk. I also tried it out in practice and the speech needed to be flipped in this handle so that everything lines up with the correct answer at the end. I think what happened is that a mix-up occurred when writing the instructions originally as the handle_no_milk_intent is placed under the YesMilkIntent and vice versa, which might have caused things to get turned around. For the sake of simplicity, I did not modify this in my pull request.

**Recommendation 2: The single apostrophe in the speech**
The single apostrophes in both the def handle_no_honey_intent and def handle_yes_honey_intent for the part of the phrase "Here's" was causing problems in python. Nothing would work until I changed the "Here's" to "Heres" while still maintaining single apostrophe throughout. I thought it simpler just to remove the single apostrophe here, but perhaps the convention should be double apostrophes for the self.speak so that "here's" doesn't cause problems. 

**Recommendation 3: The import library**
I thought it would be useful to have the necessary library import for contexts included in the guide. Simply invoking adds_context or removes_context without the import library did not work for me. I was able to find it however in the Mycroft-Core (if I recall correctly), but that was difficult as a newbie.

**Note:**
I also had an issue with the order of the adds_context and removes_context, but as I already mentioned it to Kathy (in the Chat Room), I'll just open an issue in Github for that one. I had to reverse the order, placing adds_context first and removes_context second for it to work. 

**Mycroft Version**
Using Picroft, Mycroft Core ver. 18.2.4 beta