### PR TITLE
Fix context example code - tea, milk and honey 

### DIFF
--- a/_pages/conversational-context.md
+++ b/_pages/conversational-context.md
@@ -131,13 +131,15 @@ class TeaSkill(MycroftSkill):
                                   require('MilkContext').build())
     @removes_context('MilkContext')
     @adds_context('HoneyContext')
-    def handle_yes_milk_intent(self, message):
-        self.milk = True
+    def handle_no_milk_intent(self, message):
         self.speak('all right, any Honey?', expect_response=True)
 
     @intent_handler(IntentBuilder('YesMilkIntent').require("YesKeyword").
                                   require('MilkContext').build())
-    def handle_no_milk_intent(self, message):
+    @removes_context('MilkContext')
+    @adds_context('HoneyContext')
+    def handle_yes_milk_intent(self, message):
+        self.milk = True
         self.speak('What about Honey?', expect_response=True)
 
     @intent_handler(IntentBuilder('NoHoneyIntent').require("NoKeyword").
@@ -145,18 +147,18 @@ class TeaSkill(MycroftSkill):
     @removes_context('HoneyContext')
     def handle_no_honey_intent(self, message):
         if self.milk:
-            self.speak('Heres your Tea, straight up')
-        else:
             self.speak('Heres your Tea with a dash of Milk')
+        else:
+            self.speak('Heres your Tea, straight up')
 
     @intent_handler(IntentBuilder('YesHoneyIntent').require("YesKeyword").
                                 require('HoneyContext').build())
     @removes_context('HoneyContext')
     def handle_yes_honey_intent(self, message):
         if self.milk:
-            self.speak('Heres your Tea with Honey')
-        else:
             self.speak('Heres your Tea with Milk and Honey')
+        else:
+            self.speak('Heres your Tea with Honey')
 ```
 
 When starting up only the `TeaIntent` will be available. When that has been triggered and _MilkContext_ is added the `MilkYesIntent` and `MilkNoIntent` are available since the _MilkContext_ is set. when a _yes_ or _no_ is received the _MilkContext_ is removed and can't be accessed. In it's place the _HoneyContext_ is added making the `YesHoneyIntent` and `NoHoneyIntent` available.


### PR DESCRIPTION
- The `intent_handler` and corresponding function were mismatched.
- Changed `self.milk = true` to indicate wanting milk, rather than not wanting
- Added context modification to `YesMilkIntent` handler