### PR TITLE
Remove reference to removing virtualenv

### DIFF
--- a/_pages/linux.md
+++ b/_pages/linux.md
@@ -221,10 +221,6 @@ _NOTE: depending on your system, you may need to run the commands below with `su
 
 `rm -R ~/.mycroft`
 
-* Next, remove the `virtualenv`: 
-
-`rm -R ~/.virtualenvs/mycroft`
-
 ### Common issues with Mycroft for Linux
 
 #### Removing and rebuilding your `virtualenv`


### PR DESCRIPTION
Since the move to python3 the virtualenv has been stored in the mycroft-core folder so the remove virtualenv step is incorrect.